### PR TITLE
feat: implement link card feature from markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,17 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "cheerio": "^1.0.0",
     "contentful": "^11.7.6",
     "next": "15.3.5",
+    "node-fetch": "^3.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
@@ -36,6 +39,7 @@
     "@tailwindcss/postcss": "^4",
     "@types/eslint-plugin-security": "^3.0.0",
     "@types/node": "^20",
+    "@types/node-fetch": "^2.6.11",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -184,3 +184,102 @@ body {
     background-color: #1f2937;
   }
 }
+
+/* Link Card Styles */
+.link-card {
+  margin: 1.5rem 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: box-shadow 0.2s;
+}
+
+.link-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.link-card a {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.link-card-body {
+  display: flex;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+.link-card-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.link-card-title {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.4;
+  margin-bottom: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.link-card-description {
+  font-size: 0.875rem;
+  color: #6b7280;
+  line-height: 1.4;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.link-card-url {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.link-card-site {
+  font-weight: 500;
+}
+
+.link-card-image {
+  flex-shrink: 0;
+  width: 120px;
+  height: 90px;
+}
+
+.link-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+/* Dark mode support for link cards */
+@media (prefers-color-scheme: dark) {
+  .link-card {
+    border-color: #374151;
+    background-color: #1f2937;
+  }
+
+  .link-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  }
+
+  .link-card-description {
+    color: #9ca3af;
+  }
+
+  .link-card-url {
+    color: #6b7280;
+  }
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,6 +1,7 @@
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkHtml from "remark-html";
+import { remarkLinkCard } from "./remark-link-card";
 
 /**
  * マークダウンテキストをHTMLに変換する
@@ -10,6 +11,7 @@ import remarkHtml from "remark-html";
 export async function markdownToHtml(markdown: string): Promise<string> {
   const result = await remark()
     .use(remarkGfm) // GitHub Flavored Markdownのサポート
+    .use(remarkLinkCard) // リンクカードプラグインを追加
     .use(remarkHtml) // HTMLへの変換
     .process(markdown);
 

--- a/src/lib/ogp-fetcher.ts
+++ b/src/lib/ogp-fetcher.ts
@@ -1,0 +1,33 @@
+import fetch from 'node-fetch';
+import * as cheerio from 'cheerio';
+
+export interface OGPData {
+  title: string;
+  description: string;
+  image?: string;
+  siteName?: string;
+  url: string;
+}
+
+export async function fetchOGPData(url: string): Promise<OGPData | null> {
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+    const $ = cheerio.load(html);
+
+    const ogpData: OGPData = {
+      title: $('meta[property="og:title"]').attr('content') ||
+             $('title').text() || url,
+      description: $('meta[property="og:description"]').attr('content') ||
+                   $('meta[name="description"]').attr('content') || '',
+      image: $('meta[property="og:image"]').attr('content'),
+      siteName: $('meta[property="og:site_name"]').attr('content'),
+      url: url
+    };
+
+    return ogpData;
+  } catch (error) {
+    console.error(`Failed to fetch OGP data for ${url}:`, error);
+    return null;
+  }
+}

--- a/src/lib/remark-link-card.ts
+++ b/src/lib/remark-link-card.ts
@@ -1,0 +1,81 @@
+import { visit } from 'unist-util-visit';
+import { fetchOGPData } from './ogp-fetcher';
+import type { Plugin } from 'unified';
+import type { Root, Paragraph, Link } from 'mdast';
+
+export const remarkLinkCard: Plugin<[], Root> = () => {
+  return async (tree) => {
+    const promises: Promise<void>[] = [];
+
+    visit(tree, 'paragraph', (node: Paragraph, index, parent) => {
+      // 段落内に単一のリンクのみが存在するかチェック
+      if (node.children.length === 1 &&
+          node.children[0].type === 'link') {
+
+        const link = node.children[0] as Link;
+        const url = link.url;
+
+        // リンクのテキストがURLと同じ場合のみ処理
+        if (link.children.length === 1 &&
+            link.children[0].type === 'text' &&
+            link.children[0].value === url) {
+
+          promises.push(
+            fetchOGPData(url).then(ogpData => {
+              if (ogpData && parent && typeof index === 'number') {
+                // HTMLノードとしてリンクカードを作成
+                const linkCardHtml = createLinkCardHtml(ogpData);
+
+                parent.children[index] = {
+                  type: 'html',
+                  value: linkCardHtml
+                } as any;
+              }
+            })
+          );
+        }
+      }
+    });
+
+    await Promise.all(promises);
+  };
+};
+
+function createLinkCardHtml(ogpData: OGPData): string {
+  const escapedTitle = escapeHtml(ogpData.title);
+  const escapedDescription = escapeHtml(ogpData.description);
+  const escapedSiteName = ogpData.siteName ? escapeHtml(ogpData.siteName) : '';
+
+  return `
+    <div class="link-card">
+      <a href="${ogpData.url}" target="_blank" rel="noopener noreferrer">
+        <div class="link-card-body">
+          <div class="link-card-info">
+            <div class="link-card-title">${escapedTitle}</div>
+            ${escapedDescription ? `<div class="link-card-description">${escapedDescription}</div>` : ''}
+            <div class="link-card-url">
+              ${escapedSiteName ? `<span class="link-card-site">${escapedSiteName}</span>` : ''}
+              <span>${new URL(ogpData.url).hostname}</span>
+            </div>
+          </div>
+          ${ogpData.image ? `
+            <div class="link-card-image">
+              <img src="${ogpData.image}" />
+            </div>
+          ` : ''}
+        </div>
+      </a>
+    </div>
+  `;
+}
+
+function escapeHtml(text: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+  return text.replace(/[&<>"']/g, m => map[m]);
+}


### PR DESCRIPTION
Implements link card generation from standalone URLs in markdown content.

## Changes
- Add OGP metadata fetcher for external URLs
- Create custom Remark plugin for link card generation
- Update markdown processor to include link card plugin
- Add responsive link card styles with dark mode support
- Update dependencies for node-fetch, cheerio, and unist-util-visit

## Usage
Place a standalone URL in a markdown paragraph:
```markdown
https://example.com
```

This will automatically generate a rich link card with OGP metadata.

Closes #5

Generated with [Claude Code](https://claude.ai/code)